### PR TITLE
Fix C# exceptions after picking up last rock sample.

### DIFF
--- a/Assets/Scripts/CommandServer.cs
+++ b/Assets/Scripts/CommandServer.cs
@@ -190,8 +190,11 @@ public class CommandServer : MonoBehaviour
 				sample_x.Append ( go.transform.position.x.ToString ("N2") + "," );
 				sample_y.Append ( go.transform.position.z.ToString ("N2") + "," );
 			}
-			sample_x.Remove (sample_x.Length - 1, 1);
-			sample_y.Remove (sample_y.Length - 1, 1);
+			if (ObjectiveSpawner.samples.Length != 0)
+			{
+				sample_x.Remove (sample_x.Length - 1, 1);
+				sample_y.Remove (sample_y.Length - 1, 1);
+			}
 			data["samples_x"] = sample_x.ToString ();
 			data["samples_y"] = sample_y.ToString ();
 			data["image"] = Convert.ToBase64String(CameraHelper.CaptureFrame(frontFacingCamera));

--- a/Assets/Scripts/RoverController.cs
+++ b/Assets/Scripts/RoverController.cs
@@ -457,7 +457,6 @@ public class RoverController : IRobotController
 		rb.isKinematic = true;
 //		pickupCallback = onPickup;
 		isPickingUp = true;
-		IsPickingUpSample = isPickingUp;
 		armActuator.enabled = true;
 //		Time.timeScale = 0.2f;
 //		PickupProgress = 0;
@@ -466,7 +465,11 @@ public class RoverController : IRobotController
 //			GetSample ( true );
 			TriggerPickup ();
 		}
-		StartCoroutine ( DoPickup () );
+		if (!IsPickingUpSample)
+		{
+			StartCoroutine ( DoPickup () );
+		}
+		IsPickingUpSample = isPickingUp;
 	}
 
 	IEnumerator DoPickup ()


### PR DESCRIPTION
Update the following:
1. CommandServer.cs:  Don't remove comma when there are no samples left in JSON array.
2. RoverController.cs:  Prevent race condition when adding rock samples to flatbed.


Picking up last rock sample works after this fix.
![screenshot from 2017-05-16 00-28-13](https://cloud.githubusercontent.com/assets/22384435/26090140/f432ab12-39d0-11e7-9c01-8c301cad4a6c.png)
